### PR TITLE
feat: UI Composable 함수 Modifier 필수 규칙 추가

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/src/main/kotlin/com/gwondh/composeconvention/rules/ComposeParameterOrderRule.kt
+++ b/src/main/kotlin/com/gwondh/composeconvention/rules/ComposeParameterOrderRule.kt
@@ -1,5 +1,8 @@
 package com.gwondh.composeconvention.rules
 
+import com.gwondh.composeconvention.util.String.COMPOSABLE
+import com.gwondh.composeconvention.util.String.MODIFIER
+import com.gwondh.composeconvention.util.String.PREVIEW
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
@@ -117,13 +120,5 @@ class ComposeParameterOrderRule(config: Config) : Rule(config) {
 
     private fun getErrorMessage(expected: ParamState, actual: ParamState): String {
         return "순서 위반: ${expected.name} 뒤에 ${actual.name}가 올 수 없습니다."
-    }
-
-    private fun KtNamedFunction.hasAnnotation(name: String): Boolean =
-        annotationEntries.any { it.shortName?.asString() == name }
-
-    companion object {
-        const val MODIFIER = "modifier"
-        const val COMPOSABLE = "@Composable"
     }
 }

--- a/src/main/kotlin/com/gwondh/composeconvention/rules/ComposeParameterOrderRule.kt
+++ b/src/main/kotlin/com/gwondh/composeconvention/rules/ComposeParameterOrderRule.kt
@@ -3,6 +3,7 @@ package com.gwondh.composeconvention.rules
 import com.gwondh.composeconvention.util.String.COMPOSABLE
 import com.gwondh.composeconvention.util.String.MODIFIER
 import com.gwondh.composeconvention.util.String.PREVIEW
+import com.gwondh.composeconvention.util.isUiComposable
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
@@ -10,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
@@ -29,7 +31,7 @@ class ComposeParameterOrderRule(config: Config) : Rule(config) {
     override val issue = Issue(
         id = javaClass.simpleName,
         severity = Severity.Style,
-        description = "Compose 파라미터 순서: [필수] 데이터 -> [필수] 이벤트 -> [필수] 슬롯 -> [Modifier] -> [선택] 데이터 -> [선택] 이벤트 -> [선택] 슬롯 -> 예외 슬롯",
+        description = "Modifier 파라미터 규칙과 파라미터 순서 규칙을 검사합니다.",
         debt = Debt.FIVE_MINS
     )
 
@@ -38,17 +40,30 @@ class ComposeParameterOrderRule(config: Config) : Rule(config) {
         if (!function.hasAnnotation("Composable")) return
 
         val parameters = function.valueParameters
-        if (parameters.isEmpty()) return
 
-        checkModifierOrder(function, parameters)
-        checkParametersOrder(function, parameters)
+        checkModifierRules(function, parameters)
+        checkParametersOrder(parameters)
     }
 
-    // Modifier 위치 검사
-    private fun checkModifierOrder(function: KtNamedFunction, parameters: List<KtParameter>) {
-        val modifierParameter = parameters.find { it.name == MODIFIER } ?: return
-        val firstOptionalParameter = parameters.firstOrNull { it.hasDefaultValue() }
+    // Modifier 관련 검사
+    private fun checkModifierRules(function: KtNamedFunction, parameters: List<KtParameter>) {
+        val modifierParameter = parameters.find { it.name == MODIFIER }
 
+        // UI Composable 함수 Modifier 존재 검사 (Preview 함수는 제외)
+        if (modifierParameter == null) {
+            if (isUiComposable(function) && !function.hasAnnotation(PREVIEW)) {
+                report(
+                    finding = CodeSmell(
+                        issue = issue,
+                        entity = Entity.from(function.nameIdentifier ?: function),
+                        message = "UI Composable 함수 '${function.name}'는 '$MODIFIER' 파라미터를 필수로 가져야 합니다."
+                    )
+                )
+            }
+            return
+        }
+
+        // Modifier 기본값 검사
         if (!modifierParameter.hasDefaultValue()) {
             report(
                 finding = CodeSmell(
@@ -59,6 +74,9 @@ class ComposeParameterOrderRule(config: Config) : Rule(config) {
             )
             return
         }
+
+        // Modifier 위치 검사
+        val firstOptionalParameter = parameters.firstOrNull { it.hasDefaultValue() }
         if (firstOptionalParameter != null && firstOptionalParameter != modifierParameter) {
             report(
                 finding = CodeSmell(
@@ -71,7 +89,7 @@ class ComposeParameterOrderRule(config: Config) : Rule(config) {
     }
 
     // Modifier를 고려하지 않은 전체 파라미터 순서 검사
-    private fun checkParametersOrder(function: KtNamedFunction, parameters: List<KtParameter>) {
+    private fun checkParametersOrder(parameters: List<KtParameter>) {
         // 마지막이 Composable Slot인 경우에는 순서 검사에서 제외
         val lastComposableSlot = parameters.lastOrNull()?.takeIf { isComposableSlot(it) }
         val filteredParameters =

--- a/src/main/kotlin/com/gwondh/composeconvention/util/String.kt
+++ b/src/main/kotlin/com/gwondh/composeconvention/util/String.kt
@@ -1,0 +1,7 @@
+package com.gwondh.composeconvention.util
+
+object String {
+    const val MODIFIER = "modifier"
+    const val COMPOSABLE = "Composable"
+    const val PREVIEW = "Preview"
+}

--- a/src/main/kotlin/com/gwondh/composeconvention/util/isUiComposable.kt
+++ b/src/main/kotlin/com/gwondh/composeconvention/util/isUiComposable.kt
@@ -1,0 +1,11 @@
+package com.gwondh.composeconvention.util
+
+import com.gwondh.composeconvention.util.String.COMPOSABLE
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+fun isUiComposable(function: KtNamedFunction): Boolean {
+    if (!function.hasAnnotation(COMPOSABLE)) return false
+    if (function.typeReference != null && function.typeReference?.text != "Unit") return false
+    return function.nameAsSafeName.toString().firstOrNull()?.isUpperCase() == true
+}


### PR DESCRIPTION
## 📝 변경 사항
UI Composable 함수 Modifier 필수 규칙 추가 및 코드 구조 개선

## 🎯 작업 내용
- **UI Composable 함수 Modifier 필수 규칙 추가**
  - UI Composable 함수 (`@Composable`어노테이션, 대문자로 시작, 반환 타입 Unit)는 `modifier` 파라미터 필수
  - `@Preview` 어노테이션이 있는 함수는 예외 처리
  - Modifier 미존재 시 명확한 에러 메시지 제공

- **유틸리티 함수 분리 및 구조 개선**
  - `isUiComposable()` 유틸 함수 추가
    - `@Composable` 어노테이션 체크
    - 반환 타입 `Unit` 체크
    - 함수명 첫 글자 대문자 체크
  - 상수 문자열을 `String.kt` 파일로 분리 (`COMPOSABLE`, `MODIFIER`, `PREVIEW`)

- **ComposeParameterOrderRule 개선**
  - Modifier 존재 여부 검사 로직 추가
  - 기존 Modifier 위치 및 기본값 검사 유지
  - 파라미터 순서 검사 로직 유지
  - 유틸리티 함수 활용으로 코드 가독성 향상

## 🔗 관련 이슈
#8

## 📸 스크린샷 (선택사항)
N/A